### PR TITLE
feat: Support WebP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 <!-- next-header -->
 ## [Unreleased] (ReleaseDate)
 
+### New features
+
+- Add WebP tile format support with `--tile-format webp-lossless` and `--tile-format webp-lossy` options. Use `--webp-quality` to control lossy quality (default: 75).
+
 ## [v0.0.13] (2026-03-30)
 
 ### Breaking changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +474,7 @@ version = "0.0.13"
 dependencies = [
  "clap",
  "glob",
+ "image-webp",
  "pmtiles",
  "png",
  "proj-lite",
@@ -511,6 +518,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "git+https://github.com/image-rs/image-webp#28bed2274df92d600a823004e2fedd498ead4619"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
 
 [[package]]
 name = "imgref"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ ravif = "0.13.0"
 rgb = { version = "0.8.52", features = ["bytemuck"] }
 rayon = "1.11.0"
 glob = "0.3.2"
+image-webp = { version = "0.2.4", git = "https://github.com/image-rs/image-webp" }
 
 [package.metadata.release]
 tag = true # create a single tag for the version (e.g. "v0.2.5")

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Compared to the existing solutions:
 
 - Single statically linked binary with no external runtime dependencies.
 - Supports multiple input TIFF files directly (i.e. so no pre-merge step with `gdal merge` or `gdalbuildvrt`).
-- Supports AVIF tiles.
+- Supports AVIF and WebP tiles.
 
 ## Installation
 
@@ -31,11 +31,12 @@ Options:
       --min-zoom <MIN_ZOOM>      Minimum zoom level. If omitted, it is auto-determined
       --max-zoom <MAX_ZOOM>      Maximum zoom level. If omitted, defaults to min_zoom + 3
       --resampling <RESAMPLING>  Resampling method [default: bilinear] [possible values: nearest, bilinear]
-      --tile-format <TILE_FORMAT>  Tile image format [default: avif] [possible values: avif, png]
+      --tile-format <TILE_FORMAT>  Tile image format [default: avif] [possible values: avif, png, webp-lossless, webp-lossy]
       --cache-mb <CACHE_MB>      Global chunk cache size in MiB for TIFF partial reads [default: 128]
       --quality <AVIF_QUALITY>   AVIF quality in the range 1..=100 (higher is better quality, larger files) [default: 55]
       --speed <AVIF_SPEED>       AVIF speed in the range 1..=10 (lower is slower but better compression) [default: 4]
       --png-compression <PNG_COMPRESSION>  PNG compression preset [default: default] [possible values: fast, default, best]
+      --webp-quality <WEBP_QUALITY>  WebP quality for lossy mode (1..=100) [default: 75]
   -h, --help                     Print help
 ```
 
@@ -64,10 +65,12 @@ All tiles are 512×512 pixels. When using the tiles in a map viewer, set `tileSi
 
 | Format | Encoding | File size | Speed | Best for |
 |--------|----------|-----------|-------|----------|
-| AVIF (default) | Lossy | Small | Slow | Photo imagery (ortho, satellite) |
-| PNG | Lossless | Large | Fast | Data rasters (DEM, land cover) |
+| AVIF (default) | Lossy | Smallest | Slow | Photo imagery (ortho, satellite) |
+| WebP lossy | Lossy | Small | Medium | Photo imagery, wider viewer support |
+| WebP lossless | Lossless | Medium | Medium | Data rasters with good compression |
+| PNG | Lossless | Largest | Fast | Data rasters (DEM, land cover) |
 
-**Important:** Lossy encoding (AVIF) alters pixel values, which corrupts data tiles like DEM where exact values matter. For data rasters, use `--tile-format png --resampling nearest` to preserve original values.
+**Important:** Lossy encoding (AVIF, WebP lossy) alters pixel values, which corrupts data tiles like DEM where exact values matter. For data rasters, use a lossless format (`png` or `webp-lossless`) with `--resampling nearest` to preserve original values.
 
 ## Notes
 - If GeoTIFF georeferencing tags are missing, the tool falls back to adjacent world files (`.tfw`, `.TFW`, `.tifw`, `.TIFW`) when available.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Compared to the existing solutions:
 
 - Single statically linked binary with no external runtime dependencies.
 - Supports multiple input TIFF files directly (i.e. so no pre-merge step with `gdal merge` or `gdalbuildvrt`).
-- Supports AVIF and WebP tiles.
+- Supports AVIF, PNG, and WebP tiles.
 
 ## Installation
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,15 +43,24 @@ pub struct Cli {
         value_parser = value_parser!(u8).range(1..=10)
     )]
     pub avif_speed: u8,
-    /// PNG compression preset. Ignored for AVIF.
+    /// PNG compression preset. Ignored for other formats.
     #[arg(long = "png-compression", value_enum, default_value_t = PngCompression::Balanced)]
     pub png_compression: PngCompression,
+    /// WebP quality for lossy mode in the range 1..=100 (higher is better quality, larger files). Ignored for other formats.
+    #[arg(
+        long = "webp-quality",
+        default_value_t = crate::resample::DEFAULT_WEBP_QUALITY,
+        value_parser = value_parser!(u8).range(1..=100)
+    )]
+    pub webp_quality: u8,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
 pub enum TileFormat {
     Avif,
     Png,
+    WebpLossless,
+    WebpLossy,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -39,6 +39,7 @@ pub struct ConvertOptions<'a> {
     pub avif_quality: u8,
     pub avif_speed: u8,
     pub png_compression: PngCompression,
+    pub webp_quality: u8,
 }
 
 struct SourceSpec {
@@ -251,6 +252,7 @@ pub fn convert(
         avif_quality,
         avif_speed,
         png_compression,
+        webp_quality,
     } = options;
     let cli_nodata = parse_nodata(nodata)?;
 
@@ -377,6 +379,7 @@ pub fn convert(
     let pmtiles_tile_type = match tile_format {
         TileFormat::Avif => TileType::Avif,
         TileFormat::Png => TileType::Png,
+        TileFormat::WebpLossless | TileFormat::WebpLossy => TileType::Webp,
     };
 
     let file = File::create(output)?;
@@ -396,6 +399,8 @@ pub fn convert(
     match tile_format {
         TileFormat::Avif => println!("Format: AVIF (quality={avif_quality}, speed={avif_speed})"),
         TileFormat::Png => println!("Format: PNG (compression={png_compression:?})"),
+        TileFormat::WebpLossless => println!("Format: WebP lossless"),
+        TileFormat::WebpLossy => println!("Format: WebP lossy (quality={webp_quality})"),
     }
 
     let zoom_span = (max_zoom - min_zoom + 1) as usize;
@@ -477,9 +482,9 @@ pub fn convert(
     //   Phase 3 (rayon thread pool): Render tiles from pre-loaded chunks + encode (AVIF or PNG)
     //   Phase 4 (main thread): Write encoded tiles to PMTiles
 
-    let tile_encoder = match tile_format {
+    let avif_encoder = match tile_format {
         TileFormat::Avif => Some(crate::resample::make_avif_encoder(avif_speed, avif_quality)),
-        TileFormat::Png => None,
+        _ => None,
     };
     let (encoded_tx, encoded_rx) = mpsc::channel::<(usize, Result<Option<Vec<u8>>, String>)>();
     let mut next_to_write = 0usize;
@@ -526,15 +531,24 @@ pub fn convert(
                         if rgba_buf.chunks_exact(4).all(|px| px[3] == 0) {
                             return Ok(None);
                         }
-                        let encoded = match &tile_encoder {
-                            Some(enc) => crate::resample::encode_avif(enc, rgba_buf)?,
-                            None => {
+                        let encoded = match tile_format {
+                            TileFormat::Avif => crate::resample::encode_avif(
+                                avif_encoder.as_ref().expect("avif_encoder must be set"),
+                                rgba_buf,
+                            )?,
+                            TileFormat::Png => {
                                 let compression = match png_compression {
                                     PngCompression::Fast => png::Compression::Fast,
                                     PngCompression::Balanced => png::Compression::Balanced,
                                     PngCompression::High => png::Compression::High,
                                 };
                                 crate::resample::encode_png(rgba_buf, compression)?
+                            }
+                            TileFormat::WebpLossless => {
+                                crate::resample::encode_webp(rgba_buf, None)?
+                            }
+                            TileFormat::WebpLossy => {
+                                crate::resample::encode_webp(rgba_buf, Some(webp_quality))?
                             }
                         };
                         Ok(Some(encoded))

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -479,7 +479,7 @@ pub fn convert(
     //
     //   Phase 1 (main thread, CPU): Compute which TIFF chunks each tile needs
     //   Phase 2 (main thread, sync I/O): Read + decompress + normalize all needed chunks
-    //   Phase 3 (rayon thread pool): Render tiles from pre-loaded chunks + encode (AVIF or PNG)
+    //   Phase 3 (rayon thread pool): Render tiles from pre-loaded chunks + encode (AVIF, WebP, or PNG)
     //   Phase 4 (main thread): Write encoded tiles to PMTiles
 
     let avif_encoder = match tile_format {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ fn main() -> ExitCode {
             avif_quality: cli.avif_quality,
             avif_speed: cli.avif_speed,
             png_compression: cli.png_compression,
+            webp_quality: cli.webp_quality,
         },
     );
 

--- a/src/resample/mod.rs
+++ b/src/resample/mod.rs
@@ -7,6 +7,7 @@ mod types;
 pub(crate) const TILE_SIZE: usize = 512;
 pub(crate) const DEFAULT_AVIF_QUALITY: u8 = 55;
 pub(crate) const DEFAULT_AVIF_SPEED: u8 = 4;
+pub(crate) const DEFAULT_WEBP_QUALITY: u8 = 75;
 
 pub(crate) use georef::{
     TAG_PLANAR_CONFIGURATION, read_source_metadata, source_corners_merc_georef,
@@ -14,7 +15,7 @@ pub(crate) use georef::{
 };
 pub(crate) use inputs::load_source_metadata;
 pub(crate) use nodata::parse_nodata;
-pub(crate) use render::{encode_avif, encode_png, lerp, make_avif_encoder};
+pub(crate) use render::{encode_avif, encode_png, encode_webp, lerp, make_avif_encoder};
 pub(crate) use types::{
     GeoTransform, Georef, NoDataSpec, Pt, SourceMetadata, tile_bounds_webmerc, webmerc_to_tile,
     zoom_for_tile_size,

--- a/src/resample/render.rs
+++ b/src/resample/render.rs
@@ -48,7 +48,7 @@ pub(crate) fn encode_webp(
     rgba: &[u8],
     lossy_quality: Option<u8>,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-    let mut buf = Vec::with_capacity(TILE_SIZE * TILE_SIZE);
+    let mut buf = Vec::with_capacity(TILE_SIZE * TILE_SIZE * 4);
     let mut encoder = WebPEncoder::new(&mut buf);
     if let Some(quality) = lossy_quality {
         let mut params = EncoderParams::default();

--- a/src/resample/render.rs
+++ b/src/resample/render.rs
@@ -1,3 +1,4 @@
+use image_webp::{EncoderParams, WebPEncoder};
 use ravif::{BitDepth, Encoder, Img, RGBA8};
 
 use super::{Pt, TILE_SIZE};
@@ -41,4 +42,25 @@ pub(crate) fn encode_avif(
     let img = Img::new(pixels, TILE_SIZE, TILE_SIZE);
     let encoded = encoder.encode_rgba(img)?;
     Ok(encoded.avif_file)
+}
+
+pub(crate) fn encode_webp(
+    rgba: &[u8],
+    lossy_quality: Option<u8>,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    let mut buf = Vec::with_capacity(TILE_SIZE * TILE_SIZE);
+    let mut encoder = WebPEncoder::new(&mut buf);
+    if let Some(quality) = lossy_quality {
+        let mut params = EncoderParams::default();
+        params.use_lossy = true;
+        params.lossy_quality = quality;
+        encoder.set_params(params);
+    }
+    encoder.encode(
+        rgba,
+        TILE_SIZE as u32,
+        TILE_SIZE as u32,
+        image_webp::ColorType::Rgba8,
+    )?;
+    Ok(buf)
 }


### PR DESCRIPTION
Add `webp-lossless` and `webp-lossy` to the tile format. Note that lossy encoding of WebP is not a released feature of the image-webp crate, so it might be unstable. But, let's give it a try...