### PR TITLE
Add on-demand tile serving for GeoTIFF conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -124,6 +124,12 @@ dependencies = [
  "compression-core",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -172,6 +178,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -262,7 +320,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -381,7 +439,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -417,7 +475,7 @@ checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -457,6 +515,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "geo-traits"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +566,7 @@ checksum = "2e7c353d12a704ccfab1ba8bfb1a7fe6cb18b665bf89d37f4f7890edcd260206"
 name = "geotiff-to-pmtiles"
 version = "0.0.12"
 dependencies = [
+ "axum",
  "clap",
  "glob",
  "pmtiles",
@@ -475,6 +576,7 @@ dependencies = [
  "rayon",
  "rgb",
  "tiff",
+ "tokio",
 ]
 
 [[package]]
@@ -513,6 +615,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "imgref"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,7 +708,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -545,6 +727,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -623,6 +811,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +833,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +846,17 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -697,7 +908,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -752,6 +963,12 @@ name = "pastey"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project-lite"
@@ -828,7 +1045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1013,10 +1230,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -1031,6 +1329,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1055,6 +1375,23 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tar"
@@ -1084,7 +1421,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1099,6 +1436,80 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]
@@ -1143,6 +1554,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,7 +1600,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -1256,8 +1673,14 @@ checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ ravif = "0.13.0"
 rgb = { version = "0.8.52", features = ["bytemuck"] }
 rayon = "1.11.0"
 glob = "0.3.2"
+axum = "0.8.8"
+tokio = { version = "1.49.0", features = ["rt-multi-thread", "net", "signal"] }
 
 [package.metadata.release]
 tag = true # create a single tag for the version (e.g. "v0.2.5")

--- a/README.md
+++ b/README.md
@@ -26,13 +26,15 @@ Arguments:
 
 Options:
   -o, --output <OUTPUT>          Output PMTiles path [default: out.pmtiles]
+      --serve                    Serve requested tiles dynamically instead of creating a PMTiles file
+      --bind <BIND>              Address used by preview server mode [default: 127.0.0.1:3000]
+      --cache-mb <CACHE_MB>      Decoded TIFF chunk cache size in MiB for preview server mode [default: 128]
       --src-crs <SRC_CRS>        Source CRS when GeoKeyDirectoryTag is missing (e.g. "EPSG:4326")
       --nodata <NODATA>          NoData value, e.g. "0" or "255,255,255"
       --min-zoom <MIN_ZOOM>      Minimum zoom level. If omitted, it is auto-determined
       --max-zoom <MAX_ZOOM>      Maximum zoom level. If omitted, defaults to min_zoom + 3
       --resampling <RESAMPLING>  Resampling method [default: bilinear] [possible values: nearest, bilinear]
       --tile-format <TILE_FORMAT>  Tile image format [default: avif] [possible values: avif, png]
-      --cache-mb <CACHE_MB>      Global chunk cache size in MiB for TIFF partial reads [default: 128]
       --quality <AVIF_QUALITY>   AVIF quality in the range 1..=100 (higher is better quality, larger files) [default: 55]
       --speed <AVIF_SPEED>       AVIF speed in the range 1..=10 (lower is slower but better compression) [default: 4]
       --png-compression <PNG_COMPRESSION>  PNG compression preset [default: default] [possible values: fast, default, best]
@@ -53,7 +55,18 @@ geotiff-to-pmtiles --tile-format png /path/to/*.tif
 
 # if CRS is missing, use --src-crs option
 geotiff-to-pmtiles --src-crs EPSG:6677 /path/to/*.tif
+
+# preview tiles without creating a PMTiles file
+geotiff-to-pmtiles --serve --tile-format png /path/to/*.tif
+# then use http://127.0.0.1:3000/tiles/{z}/{x}/{y}.png as an XYZ source
 ```
+
+## Preview server
+
+`--serve` loads the fixed input GeoTIFF metadata once and renders only requested
+XYZ tiles. Decoded TIFF chunks are retained in a byte-bounded LRU cache controlled
+by `--cache-mb`. The server returns `204 No Content` for tiles outside the source
+coverage or tiles that render fully transparent. Press Ctrl+C to stop it.
 
 ## Notes
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use clap::value_parser;
 
 #[derive(Debug, Parser)]
 #[command(name = "geotiff-to-pmtiles")]
-#[command(about = "Convert GeoTIFF to PMTiles with AVIF/PNG image tiles")]
+#[command(about = "Convert GeoTIFF to PMTiles or serve AVIF/PNG preview tiles")]
 pub struct Cli {
     /// Input GeoTIFF path(s) and/or glob pattern(s) (e.g. data/*.tif data/a.tif).
     #[arg(required = true, num_args = 1..)]
@@ -11,6 +11,15 @@ pub struct Cli {
     /// Output PMTiles path.
     #[arg(short, long, default_value = "out.pmtiles")]
     pub output: std::path::PathBuf,
+    /// Serve requested tiles dynamically instead of creating a PMTiles file.
+    #[arg(long)]
+    pub serve: bool,
+    /// Address used by preview server mode.
+    #[arg(long, default_value = "127.0.0.1:3000")]
+    pub bind: String,
+    /// Decoded TIFF chunk cache size in MiB for preview server mode.
+    #[arg(long, default_value_t = 128)]
+    pub cache_mb: usize,
     /// Source CRS when GeoKeyDirectoryTag is missing (e.g. "EPSG:4326").
     #[arg(long)]
     pub src_crs: Option<String>,

--- a/src/convert/cache.rs
+++ b/src/convert/cache.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
 /// Decoded chunk pixel data, normalized to u8.
 pub(crate) struct ChunkData {
     pub(crate) width: usize,
@@ -11,4 +14,112 @@ pub(crate) struct ChunkData {
 pub(crate) struct ChunkKey {
     pub(crate) source_idx: usize,
     pub(crate) chunk_idx: u32,
+}
+
+struct CacheEntry {
+    chunk: Arc<ChunkData>,
+    last_used: u64,
+}
+
+/// A deliberately small byte-bounded LRU for decoded TIFF chunks.
+///
+/// Looking up the least-recently-used entry is O(n). That keeps this preview
+/// cache dependency-free and is acceptable for the expected cache sizes.
+pub(crate) struct ChunkLruCache {
+    entries: HashMap<ChunkKey, CacheEntry>,
+    capacity_bytes: usize,
+    used_bytes: usize,
+    clock: u64,
+}
+
+impl ChunkLruCache {
+    pub(crate) fn new(capacity_bytes: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            capacity_bytes,
+            used_bytes: 0,
+            clock: 0,
+        }
+    }
+
+    pub(crate) fn get(&mut self, key: &ChunkKey) -> Option<Arc<ChunkData>> {
+        self.clock = self.clock.wrapping_add(1);
+        let entry = self.entries.get_mut(key)?;
+        entry.last_used = self.clock;
+        Some(Arc::clone(&entry.chunk))
+    }
+
+    pub(crate) fn insert(&mut self, key: ChunkKey, chunk: Arc<ChunkData>) {
+        let chunk_bytes = chunk.data.len();
+        if self.capacity_bytes == 0 || chunk_bytes > self.capacity_bytes {
+            return;
+        }
+
+        self.clock = self.clock.wrapping_add(1);
+        if let Some(previous) = self.entries.remove(&key) {
+            self.used_bytes = self.used_bytes.saturating_sub(previous.chunk.data.len());
+        }
+        self.used_bytes = self.used_bytes.saturating_add(chunk_bytes);
+        self.entries.insert(
+            key,
+            CacheEntry {
+                chunk,
+                last_used: self.clock,
+            },
+        );
+
+        while self.used_bytes > self.capacity_bytes {
+            let Some(lru_key) = self
+                .entries
+                .iter()
+                .min_by_key(|(_, entry)| entry.last_used)
+                .map(|(key, _)| *key)
+            else {
+                break;
+            };
+            if let Some(removed) = self.entries.remove(&lru_key) {
+                self.used_bytes = self.used_bytes.saturating_sub(removed.chunk.data.len());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chunk(size: usize) -> Arc<ChunkData> {
+        Arc::new(ChunkData {
+            width: size,
+            height: 1,
+            stride: 1,
+            data: vec![0; size],
+        })
+    }
+
+    #[test]
+    fn evicts_the_least_recently_used_chunk_by_byte_budget() {
+        let first = ChunkKey {
+            source_idx: 0,
+            chunk_idx: 0,
+        };
+        let second = ChunkKey {
+            source_idx: 0,
+            chunk_idx: 1,
+        };
+        let third = ChunkKey {
+            source_idx: 0,
+            chunk_idx: 2,
+        };
+        let mut cache = ChunkLruCache::new(8);
+        cache.insert(first, chunk(4));
+        cache.insert(second, chunk(4));
+        assert!(cache.get(&first).is_some());
+
+        cache.insert(third, chunk(4));
+
+        assert!(cache.get(&first).is_some());
+        assert!(cache.get(&second).is_none());
+        assert!(cache.get(&third).is_some());
+    }
 }

--- a/src/convert/mod.rs
+++ b/src/convert/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod cache;
+pub(crate) mod preview;
 mod render;
 mod source;
 
@@ -6,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::BufReader;
 use std::path::PathBuf;
-use std::sync::mpsc;
+use std::sync::{Arc, mpsc};
 
 use pmtiles::{Compression, PmTilesWriter, TileCoord, TileId, TileType};
 use proj_lite::Proj;
@@ -174,7 +175,7 @@ fn read_chunks(
     needed_chunks: &HashSet<ChunkKey>,
     decoders: &mut [Decoder<BufReader<File>>],
     layouts: &[ChunkLayout],
-) -> Result<HashMap<ChunkKey, ChunkData>, Box<dyn std::error::Error>> {
+) -> Result<HashMap<ChunkKey, Arc<ChunkData>>, Box<dyn std::error::Error>> {
     if needed_chunks.is_empty() {
         return Ok(HashMap::new());
     }
@@ -212,12 +213,12 @@ fn read_chunks(
                     source_idx: *source_idx,
                     chunk_idx,
                 },
-                ChunkData {
+                Arc::new(ChunkData {
                     width: cw,
                     height: ch,
                     stride,
                     data,
-                },
+                }),
             );
         }
     }
@@ -234,6 +235,43 @@ fn make_samplers(source_specs: &[SourceSpec]) -> Vec<SourceSampler> {
         sources.push(SourceSampler { reader: sampler });
     }
     sources
+}
+
+fn resolve_nodata(
+    sources: &[SourceMetadata],
+    cli_nodata: Option<NoDataSpec>,
+) -> Result<Option<NoDataSpec>, Box<dyn std::error::Error>> {
+    if cli_nodata.is_some() {
+        return Ok(cli_nodata);
+    }
+
+    let mut gdal_specs = HashSet::new();
+    for source in sources {
+        let Some(value) = source.gdal_nodata.as_deref() else {
+            continue;
+        };
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        match parse_nodata(Some(value)) {
+            Ok(Some(spec)) => {
+                gdal_specs.insert(spec);
+            }
+            Ok(None) => {}
+            Err(error) => {
+                eprintln!("Warning: ignoring unsupported GDAL_NODATA value `{value}`: {error}")
+            }
+        }
+    }
+
+    match gdal_specs.len() {
+        0 => Ok(None),
+        1 => Ok(gdal_specs.into_iter().next()),
+        _ => Err(
+            "conflicting GDAL_NODATA values across input sources; please specify --nodata".into(),
+        ),
+    }
 }
 
 pub fn convert(
@@ -260,45 +298,7 @@ pub fn convert(
 
     // Use CLI --nodata if provided, otherwise fall back to GDAL_NODATA tags
     // (only when all sources agree on a single value).
-    let nodata = if cli_nodata.is_some() {
-        cli_nodata
-    } else {
-        let mut gdal_specs: HashSet<NoDataSpec> = HashSet::new();
-        for meta in &sources_meta {
-            if let Some(val) = meta.gdal_nodata.as_deref() {
-                let trimmed = val.trim();
-                if trimmed.is_empty() {
-                    continue;
-                }
-                match parse_nodata(Some(trimmed)) {
-                    Ok(Some(spec)) => {
-                        gdal_specs.insert(spec);
-                    }
-                    Ok(None) => {}
-                    Err(e) => {
-                        eprintln!(
-                            "Warning: ignoring unsupported GDAL_NODATA value `{trimmed}`: {e}"
-                        );
-                    }
-                }
-            }
-        }
-
-        match gdal_specs.len() {
-            0 => None,
-            1 => {
-                let spec = gdal_specs.into_iter().next().unwrap();
-                println!("Using GDAL_NODATA value from source(s)");
-                Some(spec)
-            }
-            _ => {
-                return Err(
-                    "conflicting GDAL_NODATA values across input sources; please specify --nodata"
-                        .into(),
-                );
-            }
-        }
-    };
+    let nodata = resolve_nodata(&sources_meta, cli_nodata)?;
 
     // Open all source TIFFs and compute layouts.
     let source_paths: Vec<_> = sources_meta.iter().map(|m| m.path.clone()).collect();

--- a/src/convert/preview.rs
+++ b/src/convert/preview.rs
@@ -1,0 +1,197 @@
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::BufReader;
+use std::sync::{Arc, Mutex};
+
+use tiff::decoder::Decoder;
+
+use crate::cli::{PngCompression, TileFormat};
+use crate::resample::{NoDataSpec, Pt, TILE_SIZE, parse_nodata, source_corners_merc_georef};
+
+use super::cache::{ChunkData, ChunkKey, ChunkLruCache};
+use super::render::render_tile_chunked;
+use super::{ConvertOptions, SourceSpec, compute_chunk_requirements, make_samplers, open_sources};
+
+struct PreviewIo {
+    decoders: Vec<Decoder<BufReader<File>>>,
+    cache: ChunkLruCache,
+}
+
+/// Reusable renderer for serving arbitrary XYZ tiles from fixed local sources.
+pub(crate) struct PreviewRenderer {
+    source_specs: Vec<SourceSpec>,
+    source_bounds: Vec<(f64, f64, f64, f64)>,
+    layouts: Vec<super::source::ChunkLayout>,
+    io: Mutex<PreviewIo>,
+    nodata: Option<NoDataSpec>,
+    resampling: crate::cli::Resampling,
+    tile_format: TileFormat,
+    avif_encoder: Option<ravif::Encoder<'static>>,
+    png_compression: PngCompression,
+}
+
+impl PreviewRenderer {
+    pub(crate) fn open(
+        input: &[String],
+        options: ConvertOptions<'_>,
+        cache_bytes: usize,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let ConvertOptions {
+            src_crs,
+            nodata,
+            resampling,
+            tile_format,
+            avif_quality,
+            avif_speed,
+            png_compression,
+            ..
+        } = options;
+
+        let cli_nodata = parse_nodata(nodata)?;
+        let sources_meta = crate::resample::load_source_metadata(input, src_crs)?;
+        let nodata = super::resolve_nodata(&sources_meta, cli_nodata)?;
+        let source_paths: Vec<_> = sources_meta.iter().map(|meta| meta.path.clone()).collect();
+        let (decoders, layouts) = open_sources(&source_paths)?;
+        let source_specs: Vec<SourceSpec> = sources_meta
+            .into_iter()
+            .zip(layouts.iter().cloned())
+            .map(|(meta, layout)| SourceSpec::from_meta(meta, layout))
+            .collect();
+
+        let mut source_bounds = Vec::with_capacity(source_specs.len());
+        for source in &source_specs {
+            let corners = source_corners_merc_georef(&source.georef, source.width, source.height)?;
+            source_bounds.push(bounds_for_corners(corners));
+        }
+
+        Ok(Self {
+            source_specs,
+            source_bounds,
+            layouts,
+            io: Mutex::new(PreviewIo {
+                decoders,
+                cache: ChunkLruCache::new(cache_bytes),
+            }),
+            nodata,
+            resampling,
+            tile_format,
+            avif_encoder: match tile_format {
+                TileFormat::Avif => {
+                    Some(crate::resample::make_avif_encoder(avif_speed, avif_quality))
+                }
+                TileFormat::Png => None,
+            },
+            png_compression,
+        })
+    }
+
+    pub(crate) fn tile_format(&self) -> TileFormat {
+        self.tile_format
+    }
+
+    pub(crate) fn render_tile(
+        &self,
+        z: u8,
+        x: u32,
+        y: u32,
+    ) -> Result<Option<Vec<u8>>, Box<dyn std::error::Error>> {
+        if z > 31 {
+            return Err(format!("zoom must be <= 31, got {z}").into());
+        }
+        let dimension = 1_u64 << z;
+        if u64::from(x) >= dimension || u64::from(y) >= dimension {
+            return Err(format!("tile coordinate is outside zoom {z}: {x}/{y}").into());
+        }
+
+        let (needed_chunks, selected) =
+            compute_chunk_requirements((z, x, y), &self.source_specs, &self.source_bounds);
+        if selected.is_empty() {
+            return Ok(None);
+        }
+
+        let chunk_map = self.load_chunks(needed_chunks)?;
+        let mut samplers = make_samplers(&self.source_specs);
+        let mut rgba = Vec::with_capacity(TILE_SIZE * TILE_SIZE * 4);
+        render_tile_chunked(
+            &mut samplers,
+            &selected,
+            self.resampling,
+            self.nodata,
+            &chunk_map,
+            &mut rgba,
+        )?;
+
+        if rgba.chunks_exact(4).all(|pixel| pixel[3] == 0) {
+            return Ok(None);
+        }
+
+        let encoded = match self.tile_format {
+            TileFormat::Avif => {
+                let encoder = self
+                    .avif_encoder
+                    .as_ref()
+                    .expect("AVIF encoder is initialized for AVIF output");
+                crate::resample::encode_avif(encoder, &rgba)?
+            }
+            TileFormat::Png => {
+                let compression = match self.png_compression {
+                    PngCompression::Fast => png::Compression::Fast,
+                    PngCompression::Balanced => png::Compression::Balanced,
+                    PngCompression::High => png::Compression::High,
+                };
+                crate::resample::encode_png(&rgba, compression)?
+            }
+        };
+        Ok(Some(encoded))
+    }
+
+    fn load_chunks(
+        &self,
+        needed_chunks: HashSet<ChunkKey>,
+    ) -> Result<HashMap<ChunkKey, Arc<ChunkData>>, Box<dyn std::error::Error>> {
+        let mut io = self
+            .io
+            .lock()
+            .map_err(|_| std::io::Error::other("preview TIFF state lock was poisoned"))?;
+        let mut chunk_map = HashMap::with_capacity(needed_chunks.len());
+        let mut missing = HashSet::new();
+
+        for key in needed_chunks {
+            if let Some(chunk) = io.cache.get(&key) {
+                chunk_map.insert(key, chunk);
+            } else {
+                missing.insert(key);
+            }
+        }
+
+        if !missing.is_empty() {
+            let loaded = super::read_chunks(&missing, &mut io.decoders, &self.layouts)?;
+            for (key, chunk) in loaded {
+                io.cache.insert(key, Arc::clone(&chunk));
+                chunk_map.insert(key, chunk);
+            }
+        }
+
+        Ok(chunk_map)
+    }
+}
+
+fn bounds_for_corners(corners: [Pt; 4]) -> (f64, f64, f64, f64) {
+    let min_x = corners
+        .iter()
+        .map(|point| point.x)
+        .fold(f64::INFINITY, f64::min);
+    let max_x = corners
+        .iter()
+        .map(|point| point.x)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let min_y = corners
+        .iter()
+        .map(|point| point.y)
+        .fold(f64::INFINITY, f64::min);
+    let max_y = corners
+        .iter()
+        .map(|point| point.y)
+        .fold(f64::NEG_INFINITY, f64::max);
+    (min_x, min_y, max_x, max_y)
+}

--- a/src/convert/render.rs
+++ b/src/convert/render.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::cli::Resampling;
 use crate::resample::{NoDataSpec, Pt, lerp};
@@ -21,7 +22,7 @@ pub(super) fn render_tile_chunked(
     selected: &[(usize, [Pt; 4])],
     resampling: Resampling,
     nodata: Option<NoDataSpec>,
-    chunk_map: &HashMap<ChunkKey, ChunkData>,
+    chunk_map: &HashMap<ChunkKey, Arc<ChunkData>>,
     out: &mut Vec<u8>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Render one TILE_SIZE x TILE_SIZE output tile in scanline order.
@@ -95,7 +96,7 @@ fn sample_nearest_multi(
     samplers: &mut [SourceSampler],
     cursors: &[RowSampleCursor],
     nodata: Option<NoDataSpec>,
-    chunk_map: &HashMap<ChunkKey, ChunkData>,
+    chunk_map: &HashMap<ChunkKey, Arc<ChunkData>>,
 ) -> Result<[u8; 4], Box<dyn std::error::Error>> {
     // First source in input order that yields a valid (non-nodata) sample wins.
     for c in cursors {
@@ -110,7 +111,7 @@ fn sample_bilinear_multi(
     samplers: &mut [SourceSampler],
     cursors: &[RowSampleCursor],
     nodata: Option<NoDataSpec>,
-    chunk_map: &HashMap<ChunkKey, ChunkData>,
+    chunk_map: &HashMap<ChunkKey, Arc<ChunkData>>,
 ) -> Result<[u8; 4], Box<dyn std::error::Error>> {
     // Bilinear policy across sources: first source in input order that yields a valid sample wins.
     for c in cursors {
@@ -128,7 +129,7 @@ fn sample_nearest_opt(
     x: f64,
     y: f64,
     nodata: Option<NoDataSpec>,
-    chunk_map: &HashMap<ChunkKey, ChunkData>,
+    chunk_map: &HashMap<ChunkKey, Arc<ChunkData>>,
 ) -> Result<Option<[u8; 4]>, Box<dyn std::error::Error>> {
     let xi = x.round() as isize;
     let yi = y.round() as isize;
@@ -149,7 +150,7 @@ fn sample_bilinear_opt(
     x: f64,
     y: f64,
     nodata: Option<NoDataSpec>,
-    chunk_map: &HashMap<ChunkKey, ChunkData>,
+    chunk_map: &HashMap<ChunkKey, Arc<ChunkData>>,
 ) -> Result<Option<[u8; 4]>, Box<dyn std::error::Error>> {
     let x0 = x.floor();
     let y0 = y.floor();

--- a/src/convert/source.rs
+++ b/src/convert/source.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::io::{Read, Seek};
+use std::sync::Arc;
 
 use tiff::decoder::{Decoder, DecodingResult};
 
@@ -215,7 +216,7 @@ impl SourceSampler {
         source_idx: usize,
         xi: isize,
         yi: isize,
-        chunk_map: &HashMap<ChunkKey, ChunkData>,
+        chunk_map: &HashMap<ChunkKey, Arc<ChunkData>>,
     ) -> Result<Option<[u8; 4]>, Box<dyn std::error::Error>> {
         let Some((chunk_idx, lx, ly)) = self.reader.chunk_and_local(xi, yi) else {
             return Ok(None);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod cli;
 mod convert;
 mod resample;
+mod server;
 
 use std::process::ExitCode;
 
@@ -10,21 +11,23 @@ use cli::Cli;
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    let result = convert::convert(
-        &cli.input,
-        &cli.output,
-        convert::ConvertOptions {
-            src_crs: cli.src_crs.as_deref(),
-            nodata: cli.nodata.as_deref(),
-            min_zoom: cli.min_zoom,
-            max_zoom: cli.max_zoom,
-            resampling: cli.resampling,
-            tile_format: cli.tile_format,
-            avif_quality: cli.avif_quality,
-            avif_speed: cli.avif_speed,
-            png_compression: cli.png_compression,
-        },
-    );
+    let options = convert::ConvertOptions {
+        src_crs: cli.src_crs.as_deref(),
+        nodata: cli.nodata.as_deref(),
+        min_zoom: cli.min_zoom,
+        max_zoom: cli.max_zoom,
+        resampling: cli.resampling,
+        tile_format: cli.tile_format,
+        avif_quality: cli.avif_quality,
+        avif_speed: cli.avif_speed,
+        png_compression: cli.png_compression,
+    };
+
+    let result = if cli.serve {
+        server::serve(&cli.input, options, &cli.bind, cli.cache_mb)
+    } else {
+        convert::convert(&cli.input, &cli.output, options)
+    };
 
     match result {
         Ok(()) => ExitCode::SUCCESS,

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,144 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::Router;
+use axum::body::Body;
+use axum::extract::{Path, State};
+use axum::http::{StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+
+use crate::cli::TileFormat;
+use crate::convert::ConvertOptions;
+use crate::convert::preview::PreviewRenderer;
+
+#[derive(Clone)]
+struct AppState {
+    renderer: Arc<PreviewRenderer>,
+    extension: &'static str,
+    content_type: &'static str,
+}
+
+pub(crate) fn serve(
+    input: &[String],
+    options: ConvertOptions<'_>,
+    bind: &str,
+    cache_mb: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let address: SocketAddr = bind
+        .parse()
+        .map_err(|error| format!("invalid --bind address `{bind}`: {error}"))?;
+    let cache_bytes = cache_mb
+        .checked_mul(1024 * 1024)
+        .ok_or("--cache-mb is too large")?;
+    let renderer = Arc::new(PreviewRenderer::open(input, options, cache_bytes)?);
+    let (extension, content_type) = match renderer.tile_format() {
+        TileFormat::Avif => ("avif", "image/avif"),
+        TileFormat::Png => ("png", "image/png"),
+    };
+    let state = AppState {
+        renderer,
+        extension,
+        content_type,
+    };
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    runtime.block_on(run(address, state))
+}
+
+async fn run(address: SocketAddr, state: AppState) -> Result<(), Box<dyn std::error::Error>> {
+    let extension = state.extension;
+    let app = Router::new()
+        .route("/", get(index))
+        .route("/tiles/{z}/{x}/{y}", get(tile))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind(address).await?;
+    let local_address = listener.local_addr()?;
+
+    println!("Preview tile server listening on http://{local_address}");
+    println!("XYZ template: http://{local_address}/tiles/{{z}}/{{x}}/{{y}}.{extension}");
+    println!("Press Ctrl+C to stop.");
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+    Ok(())
+}
+
+async fn index(State(state): State<AppState>) -> String {
+    format!(
+        "GeoTIFF preview server\n\nTile endpoint: /tiles/{{z}}/{{x}}/{{y}}.{}\n",
+        state.extension
+    )
+}
+
+async fn tile(
+    State(state): State<AppState>,
+    Path((z, x, y_component)): Path<(u8, u32, String)>,
+) -> Response {
+    let y = match parse_y(&y_component, state.extension) {
+        Ok(y) => y,
+        Err(status) => return status.into_response(),
+    };
+    if z > 31 {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+    let dimension = 1_u64 << z;
+    if u64::from(x) >= dimension || u64::from(y) >= dimension {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+    let renderer = Arc::clone(&state.renderer);
+    let rendered = tokio::task::spawn_blocking(move || {
+        renderer
+            .render_tile(z, x, y)
+            .map_err(|error| error.to_string())
+    })
+    .await;
+
+    match rendered {
+        Ok(Ok(Some(bytes))) => Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, state.content_type)
+            .body(Body::from(bytes))
+            .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response()),
+        Ok(Ok(None)) => StatusCode::NO_CONTENT.into_response(),
+        Ok(Err(error)) => (StatusCode::INTERNAL_SERVER_ERROR, error).into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("tile worker failed: {error}"),
+        )
+            .into_response(),
+    }
+}
+
+fn parse_y(component: &str, expected_extension: &str) -> Result<u32, StatusCode> {
+    let (number, extension) = match component.rsplit_once('.') {
+        Some(parts) => parts,
+        None => (component, expected_extension),
+    };
+    if extension != expected_extension {
+        return Err(StatusCode::NOT_FOUND);
+    }
+    number.parse().map_err(|_| StatusCode::BAD_REQUEST)
+}
+
+async fn shutdown_signal() {
+    if let Err(error) = tokio::signal::ctrl_c().await {
+        eprintln!("failed to listen for Ctrl+C: {error}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_y_with_or_without_the_configured_extension() {
+        assert_eq!(parse_y("12", "png"), Ok(12));
+        assert_eq!(parse_y("12.png", "png"), Ok(12));
+        assert_eq!(parse_y("12.avif", "png"), Err(StatusCode::NOT_FOUND));
+        assert_eq!(parse_y("nope.png", "png"), Err(StatusCode::BAD_REQUEST));
+    }
+}


### PR DESCRIPTION
## Summary

- Add on-demand tile serving to the conversion workflow
- Update rendering, preview, source, cache, and server components to support tile requests
- Refresh CLI behavior, dependencies, and documentation

## Testing

- Not run (not requested)